### PR TITLE
Update ci_verify.sh to use tar to copy files rather than base64

### DIFF
--- a/template/{% if  git_platform == 'gitlab.diamond.ac.uk' %}.gitlab{% endif %}/ci_verify.sh
+++ b/template/{% if  git_platform == 'gitlab.diamond.ac.uk' %}.gitlab{% endif %}/ci_verify.sh
@@ -31,12 +31,11 @@ do
         echo "Validating ${service} with ${image}"
 
         # This will fail and exit if the ioc.yaml is invalid
-        config="$(cat ${service}/config/ioc.yaml | base64)"
+        tar cf - ${service}/config | \
         kubectl run ${POD} -iq --restart Never --image ${image} \
-                --command -- bash -c "set -xe && mkdir config \
-                && echo \"$config\" | base64 -d > config/ioc.yaml \
-                && cat config/ioc.yaml \
-                && ibek runtime generate config/ioc.yaml /epics/ibek-defs/*" \
+                --command -- bash -c "tar xf - \
+                && cat ${service}/config/ioc.yaml \
+                && ibek runtime generate ${service}/config/ioc.yaml /epics/ibek-defs/*" \
                 &>/dev/null || { echo Failed; status=1; }
         kubectl wait --for=condition=ready=False --timeout=30s pod/${POD}
         kubectl logs ${POD}


### PR DESCRIPTION
From `kubectl cp --help`
```
[esq51579@pc0146 ~]$ kubectl cp --help
Copy files and directories to and from containers.

Examples:
  # !!!Important Note!!!
  # Requires that the 'tar' binary is present in your container
  # image.  If 'tar' is not present, 'kubectl cp' will fail.
  #
  # For advanced use cases, such as symlinks, wildcard expansion or
  # file mode preservation, consider using 'kubectl exec'.
  
  # Copy /tmp/foo local file to /tmp/bar in a remote pod in namespace <some-namespace>
  tar cf - /tmp/foo | kubectl exec -i -n <some-namespace> <some-pod> -- tar xf - -C /tmp/bar

```
This PR applies the approach suggested in the kubectl documentation